### PR TITLE
Dockerfile image size optimisation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+name: "CodeQL"
+on:
+  push:
+    branches: [ master ]
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'go' ]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Ignore text editor files
+.vscode
+.idea
+
 # If you prefer the allow list template instead of the deny list, see community template:
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,24 @@
-FROM golang:1.21.1
+FROM golang:1.21-alpine AS builder
 
-RUN mkdir -p /app
+ARG ARCH=amd64
 
-WORKDIR /app
+ENV GOROOT /usr/local/go
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
+ENV GO_VERSION 1.21
+ENV GO111MODULE on
+ENV CGO_ENABLED=0
 
-ADD . /app
+# Build dependencies
+WORKDIR /go/src/
+COPY . .
+RUN apk update && apk add make git
+RUN go get .
+RUN mkdir /go/src/build 
+RUN go build -a -gcflags=all="-l -B" -ldflags="-w -s" -o build/p2c .
 
-RUN go build ./p2c.go
+# Second stage
+FROM alpine:3.19
 
-CMD ["./p2c"]
+COPY --from=builder /go/src/build/p2c /usr/local/bin/p2c
+CMD ["/usr/local/bin/p2c"]


### PR DESCRIPTION
Hi,

The current Dockerfile use the common Golang build image.
This result in large output image.

Usual workflow is to use 2 setps image process with the Golang to compile the go code in a binarie and then move this artifact to a samller base image.

This pull request implement this workflow, also update the .gitignore to escape usual text editor config file and finally added a new workflow CodeQL pour validate the code generated.